### PR TITLE
added libxrandr-dev to Linux readme and getDeps.sh

### DIFF
--- a/Builds/Linux/README.txt
+++ b/Builds/Linux/README.txt
@@ -20,8 +20,9 @@ sudo apt-get install libcsnd-dev
 sudo apt-get install libsndfile1
 sudo apt-get install libsndfile1-dev
 sudo apt-get install libjack-dev
+sudo apt-get install libxrandr-dev
 
-Please make sure that the version of Csound you use is 6.03 or newer, otherwise you will get build problems. You'll also need to have the VST SDK. 
+Please make sure that the version of Csound you use is 6.03 or newer, otherwise you will get build problems. You'll also need to have the VST SDK.
 
 If you are having problems viewing fonts you should get the following package:
 

--- a/Builds/Linux/getDeps.sh
+++ b/Builds/Linux/getDeps.sh
@@ -9,4 +9,5 @@ sudo apt-get -y install libxcomposite-dev
 sudo apt-get install libsndfile1
 sudo apt-get install libsndfile1-dev
 sudo apt-get install libjack-dev
+sudo apt-get install libxrandr-dev
 sudo apt-get install msttcorefonts


### PR DESCRIPTION
I needed libxrandr-dev, and it's been advised more than once in the forums. This should be fine when the develop branch is merged into master for the next release, right?
